### PR TITLE
rfoo._rfoo._dumps uses marshal.version == 2

### DIFF
--- a/rfoo/_rfoo.py
+++ b/rfoo/_rfoo.py
@@ -103,7 +103,7 @@ INTEGER = 'i'.encode()[0]
 
 
 _loads = _marshal.loads
-_dumps = _marshal.dumps
+_dumps = lambda x: _marshal.dumps(x, 2)
 
 
 


### PR DESCRIPTION
When marshal.version used is >= 3, we would fail the
`buffer[0] != INTEGER` check in the Connection class, and so this
commit always uses marshal.version of 2, which is the latest version
that passes the check (and also the default version used by Python 2).

The latest marshal.version is 2 for Python 2, and up to Python 3.3.
Starting with Python 3.4, the latest marshal.version is 4.