### PR TITLE
Fix pipe client initialization exception (raised by parent initializer)

### DIFF
--- a/rfoo/_rfoo.py
+++ b/rfoo/_rfoo.py
@@ -345,9 +345,14 @@ class PipeSocket(object):
 
 class PipeConnection(Connection):
     """Connection type for pipes."""
+    def __init__(self):
+        # do nothing here. We don't have the socket object yet
+        pass
 
     def connect(self, pipe_socket):
-        self._conn = pipe_socket
+        # initialize parent with pipe socket
+        # and connect
+        Connection.__init__(self, pipe_socket)
         self._conn.connect()
         return self
 


### PR DESCRIPTION
PipeConnection used parent initializer, which resulted in accessing `recv` property of None on line 223

```

class Connection(object):

    def __init__(self, conn=None):
        self._conn = conn
        self.recv = self._conn.recv
```

This fix introduces noop initializer for PipeConnection object and initializes the parent when the socket is available.